### PR TITLE
Update VFN yaml template to include mempool's default_failovers addition.

### DIFF
--- a/docs/validators/yaml-templates/vfn-yaml.md
+++ b/docs/validators/yaml-templates/vfn-yaml.md
@@ -37,4 +37,7 @@ full_node_networks:
 api:
   enabled: true
   address: '0.0.0.0:8080'
+
+mempool:
+  default_failovers: 3
 ```


### PR DESCRIPTION
Libra-framework PR is here: https://github.com/0LNetworkCommunity/libra-framework/pull/163