### PR TITLE
Update vfn-setup.md

### DIFF
--- a/docs/validators/vfn-setup.md
+++ b/docs/validators/vfn-setup.md
@@ -150,7 +150,7 @@ transaction success  ·····························�
 
 Wait (up until one epoch) and then check the on-chain values to confirm
 ``` bash
-libra query val-config -a 0xabc4321yourvalidatoraccount | jq
+libra query val-config 0xabc4321yourvalidatoraccount | jq
 ```
 
 ### Run the VFN


### PR DESCRIPTION
Fix
```
ubuntu@vfn:~$ libra query val-config -a bla
error: unexpected argument '-a' found

  tip: to pass '-a' as a value, use '-- -a'

Usage: libra query val-config <ACCOUNT>

For more information, try '--help'.
```