### PR TITLE
[ci] patch previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Echo
-        run: echo preview-${{ github.ref }}
       - name: Checkout
         uses: actions/checkout@v3
       - uses: oven-sh/setup-bun@v2
       # this has to match docusaurus's baseURL in docusaurus.config.js
       - run: echo "GH_ACTION_DOCUSAURUS_BASE_URL=pr-preview/pr-${{ github.event.number }}" >> "$GITHUB_ENV"
 
+      - name: Echo
+        run: echo preview-${{ github.ref }}
       - name: Install and Build
         if: github.event.action != 'closed' # You might want to skip the build if the PR has been closed
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,18 +1,19 @@
 # .github/workflows/preview.yml
-name: Deploy PR previews Two
+name: Deploy PR previews
 
 on:
   pull_request:
     types:
-      # - opened
-      # - reopened
+      - opened
+      - reopened
       - synchronize
-      # - closed
-
-# concurrency: preview-${{ github.ref }}
+      - closed
 
 jobs:
   deploy-preview:
+    concurrency:
+      group: preview-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,13 +1,13 @@
 # .github/workflows/preview.yml
-name: Deploy PR previews
+name: Deploy PR previews Two
 
 on:
   pull_request:
     types:
-      - opened
-      - reopened
+      # - opened
+      # - reopened
       - synchronize
-      - closed
+      # - closed
 
 # concurrency: preview-${{ github.ref }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: echo preview-${{ github.ref }}
+      - name: Echo
+        run: echo preview-${{ github.ref }}
       - name: Checkout
         uses: actions/checkout@v3
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,7 @@ on:
       - synchronize
       - closed
 
-concurrency: preview-${{ github.ref }}
+# concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - run: echo preview-${{ github.ref }}
       - name: Checkout
         uses: actions/checkout@v3
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,7 @@
 name: Deploy PR previews
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,16 +3,19 @@ name: Test deployment
 on:
   push:
     branches: ["*"]
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    branches:
-      - "main**"
+  # note: not testing on PR, since we are already previews for PRs
+  # which have the same effect
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #   branches:
+  #     - "main**"
 
 jobs:
   test-deploy:
     name: Test deployment
+    if: (github.event_name != 'pull_request')
     runs-on: ubuntu-latest
     steps:
       # NOTE: for debugging CI this allow shell access to github runner. Will print out tmate.io terminal url

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,6 @@ on:
 jobs:
   test-deploy:
     name: Test deployment
-    if: ${{github.event_name != 'pull_request'}}
     runs-on: ubuntu-latest
     steps:
       # NOTE: for debugging CI this allow shell access to github runner. Will print out tmate.io terminal url

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   test-deploy:
     name: Test deployment
-    if: (github.event_name != 'pull_request')
+    if: ${{github.event_name != 'pull_request'}}
     runs-on: ubuntu-latest
     steps:
       # NOTE: for debugging CI this allow shell access to github runner. Will print out tmate.io terminal url

--- a/docs/about/test.md
+++ b/docs/about/test.md
@@ -1,1 +1,0 @@
-# about hi

--- a/docs/about/test.md
+++ b/docs/about/test.md
@@ -1,0 +1,1 @@
+# about hi


### PR DESCRIPTION
Should run on `pull_request` on the submitted code, not `pull_request_target` which runs on the destination branch `main`.